### PR TITLE
Remove line breaks

### DIFF
--- a/charts/xxl-job-admin/templates/_helpers.tpl
+++ b/charts/xxl-job-admin/templates/_helpers.tpl
@@ -75,8 +75,7 @@ Create the name of the service account to use
 jdbc datasource url
 */}}
 {{- define "xxl-job-admin.spring.datasource.url" -}}
-{{- printf "--spring.datasource.url=jdbc:mysql://%s:%d/%s?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&serverTimezone=%s --spring.datasource.username=%s --spring.datasource.password=%s"
-.Values.database.db_address (.Values.database.db_port | int) .Values.database.db_name .Values.database.serverTimezone .Values.database.user .Values.database.password}}
+{{- printf "--spring.datasource.url=jdbc:mysql://%s:%d/%s?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&serverTimezone=%s --spring.datasource.username=%s --spring.datasource.password=%s" .Values.database.db_address (.Values.database.db_port | int) .Values.database.db_name .Values.database.serverTimezone .Values.database.user .Values.database.password}}
 {{- end}}
 
 {{/*


### PR DESCRIPTION
Remove line breaks to improve deployment compatibility issues on some cloud platforms (such as KubeSphere)