### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/charts/fleet-management/values.yaml
+++ b/charts/fleet-management/values.yaml
@@ -587,7 +587,7 @@ defaults:
 ##
 preDeleteHook:
   enabled: false
-  image: bitnami/kubectl:latest
+  image: soldevelo/kubectl:latest
   imagePullPolicy: IfNotPresent
 
 ## Extra Kubernetes objects to deploy alongside the chart.

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -2194,7 +2194,7 @@ volumePermissions:
   ##
   image:
     registry: ghcr.io
-    repository: dellnoantechnp/bitnami/os-shell
+    repository: soldevelo/os-shell
     tag: latest
     digest: ""
     pullPolicy: IfNotPresent
@@ -2337,7 +2337,7 @@ sysctl:
   ##
   image:
     registry: ghcr.io
-    repository: dellnoantechnp/bitnami/os-shell
+    repository: soldevelo/os-shell
     tag: latest
     digest: ""
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/os-shell:latest` → [`soldevelo/os-shell:latest`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/kubectl:latest` → [`soldevelo/kubectl:latest`](https://hub.docker.com/r/soldevelo/kubectl)